### PR TITLE
allow white-list of paths to be excluded from redirect middleware

### DIFF
--- a/redirect/redirect.go
+++ b/redirect/redirect.go
@@ -9,22 +9,22 @@ import (
 
 // SecureRedirectMiddleware redirects the client to the identical URL served via HTTPS
 type SecureRedirectMiddleware struct {
-	WhiteListedPaths map[string]struct{}
+	AllowedInsecurePaths map[string]struct{}
 }
 
-func NewSecureRedirectMiddleware(paths ...string) SecureRedirectMiddleware {
+func NewSecureRedirectMiddleware(allowedInsecurepaths ...string) SecureRedirectMiddleware {
 	uniquePaths := make(map[string]struct{})
-	for _, p := range paths {
+	for _, p := range allowedInsecurepaths {
 		uniquePaths[p] = struct{}{}
 	}
 	return SecureRedirectMiddleware{
-		WhiteListedPaths: uniquePaths,
+		AllowedInsecurePaths: uniquePaths,
 	}
 }
 
 func (srm SecureRedirectMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
 	return func(w rest.ResponseWriter, r *rest.Request) {
-		_, whiteListed := srm.WhiteListedPaths[r.URL.Path]
+		_, whiteListed := srm.AllowedInsecurePaths[r.URL.Path]
 		if strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "http" && !whiteListed {
 			redirectURL := r.URL
 			redirectURL.Host = r.Host

--- a/redirect/redirect.go
+++ b/redirect/redirect.go
@@ -8,11 +8,24 @@ import (
 )
 
 // SecureRedirectMiddleware redirects the client to the identical URL served via HTTPS
-type SecureRedirectMiddleware struct{}
+type SecureRedirectMiddleware struct {
+	WhiteListedPaths map[string]struct{}
+}
 
-func (SecureRedirectMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
+func NewSecureRedirectMiddleware(paths ...string) SecureRedirectMiddleware {
+	uniquePaths := make(map[string]struct{})
+	for _, p := range paths {
+		uniquePaths[p] = struct{}{}
+	}
+	return SecureRedirectMiddleware{
+		WhiteListedPaths: uniquePaths,
+	}
+}
+
+func (srm SecureRedirectMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
 	return func(w rest.ResponseWriter, r *rest.Request) {
-		if strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "http" {
+		_, whiteListed := srm.WhiteListedPaths[r.URL.Path]
+		if strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "http" && !whiteListed {
 			redirectURL := r.URL
 			redirectURL.Host = r.Host
 			redirectURL.Scheme = "https"


### PR DESCRIPTION
* sometimes we would want certain paths to go through over plain HTTP. allow those paths by configuring a white-list at the time of creating the middleware.
* white-listed paths are case-sensitive.